### PR TITLE
[bugfix] use snake case on generated files for query params

### DIFF
--- a/gen/fields.go
+++ b/gen/fields.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	"github.com/dave/dst"
+	"github.com/schmurfy/chipi/shared"
 )
 
 type commentedField struct {
@@ -69,7 +70,7 @@ func GenerateFieldAnnotations(w io.Writer, f *dst.File, pkgName string) error {
 		}
 
 		if sectionName == "Query" {
-			fieldName = strings.ToLower(fieldName)
+			fieldName = shared.ToSnakeCase(fieldName)
 		}
 
 		cf := commentedField{


### PR DESCRIPTION
When using query params with more than one work like `CustomQuery` the effectively used param is `custom_query` but the field name in generated code is `customquery` and therefore examples given for the field do not appear...